### PR TITLE
로컬 회원가입 시 mapper 수정

### DIFF
--- a/src/main/java/gwangjang/server/domain/auth/application/dto/request/LocalSignUpRequest.java
+++ b/src/main/java/gwangjang/server/domain/auth/application/dto/request/LocalSignUpRequest.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class LocalSignUpRequest {

--- a/src/main/java/gwangjang/server/domain/auth/application/mapper/MemberMapper.java
+++ b/src/main/java/gwangjang/server/domain/auth/application/mapper/MemberMapper.java
@@ -34,6 +34,11 @@ public class MemberMapper {
                 .email(localSignUpRequest.getEmail())
                 .role(Role.USER)
                 .registrationStatus(RegistrationStatus.COMPLETED)
+                .birth(localSignUpRequest.getBirthDate())
+                .nickname(localSignUpRequest.getNickname())
+                .gender(localSignUpRequest.getGender())
+                .loginId(localSignUpRequest.getId())
+                .loginPw(localSignUpRequest.getPw())
                 .build();
     }
 

--- a/src/main/java/gwangjang/server/domain/auth/exception/EmailDuplicationException.java
+++ b/src/main/java/gwangjang/server/domain/auth/exception/EmailDuplicationException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public class EmailDuplicationException extends AuthException {
     public EmailDuplicationException(){
-        super(ErrorCode.NICKNAME_DUPLICATION_ERROR,
+        super(ErrorCode.EMAIL_DUPLICATION_ERROR,
                 HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트
- [ ] 기타 사소한 수정
  
## 개요
- [로컬 회원가입 시 mapper 수정](https://github.com/kusitms-28th-Meetup-E/BE-Member-Server/commit/333cffd9c06212f06ed472561f32e7b3f3355085)
## 변경 사항
- mapToMember 매퍼에 필드를 추가하지 않아 null 값으로 들어왔다 ㅎㅎ
https://github.com/kusitms-28th-Meetup-E/BE-Member-Server/blob/333cffd9c06212f06ed472561f32e7b3f3355085/src/main/java/gwangjang/server/domain/auth/application/mapper/MemberMapper.java#L37-L41
